### PR TITLE
Editor nur einmal pro textarea initialisieren

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -159,7 +159,7 @@ rex_markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 //Start - functions for textile
 	function btnTextileMediaCallback (h) {
 		var mediapool = openMediaPool('markitup_media');
-		$(window).on('rex:selectMedia', function (event, filename) {
+		$(mediapool).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
 			
@@ -186,7 +186,7 @@ rex_markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 	
 	function btnTextileLinkMediaCallback () {
 		var mediapool = openMediaPool('markitup_link');
-		$(window).on('rex:selectMedia', function (event, filename) {
+		$(mediapool).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
 			

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -159,7 +159,7 @@ rex_markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 //Start - functions for textile
 	function btnTextileMediaCallback (h) {
 		var mediapool = openMediaPool('markitup_media');
-		$(mediapool).on('rex:selectMedia', function (event, filename) {
+		$(window).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
 			
@@ -186,7 +186,7 @@ rex_markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 	
 	function btnTextileLinkMediaCallback () {
 		var mediapool = openMediaPool('markitup_link');
-		$(mediapool).on('rex:selectMedia', function (event, filename) {
+		$(window).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
 			

--- a/boot.php
+++ b/boot.php
@@ -19,7 +19,7 @@
 			$jsCode[] = 'function markitupInit() {';
 			foreach ($profiles as $profile) {
 				$cssCode[] = '  textarea.markitupEditor-'.$profile['name'].' { min-height: '.$profile['minheight'].'px; max-height: '.$profile['maxheight'].'px; }';
-				$jsCode[] = '  $(\'.markitupEditor-'.$profile['name'].'\').markItUp({';
+				$jsCode[] = '  $(\'.markitupEditor-'.$profile['name'].'\').not(\'.markitupActive\').markItUp({';
 				
 				$jsCode[] = '    nameSpace: "markitup_'.$profile['type'].'",';
 				switch ($profile['type']) {
@@ -31,7 +31,7 @@
 				$jsCode[] = '    markupSet: [';
 				$jsCode[] = '      '.rex_markitup::defineButtons($profile['type'], $profile['markitup_buttons'], $this);
 				$jsCode[] = '    ]';
-				$jsCode[] = '  });';
+				$jsCode[] = '  }).addClass(\'markitupActive\');';
 			}
 			$jsCode[] = '}';
 			


### PR DESCRIPTION
Der Editor wird bei `ready` und `pjax:success` an die textareas gepappt. Dadurch kann es passieren, dass eine textarea mehrfach mit Editor beglückt wird (siehe Anhang).

![waaahhhhh](https://cloud.githubusercontent.com/assets/7223820/18055019/9309dcc0-6e06-11e6-82db-ee32df77c44c.png)
