### PR TITLE
read the addons config only once

### DIFF
--- a/lib/class.markitup.php
+++ b/lib/class.markitup.php
@@ -53,7 +53,11 @@
 		}
 		
 		public static function defineButtons($type, $profileButtons, $that) {
-			$markItUpButtons = rex_file::getConfig(rex_path::addon('markitup', 'config.yml'));
+			static $markItUpButtons = null;
+
+			if (!$markItUpButtons) {
+				$markItUpButtons = rex_file::getConfig(rex_path::addon('markitup', 'config.yml'));
+			}
 			
 			$buttonString = '';
 			$profileButtons = explode(',', $profileButtons);


### PR DESCRIPTION
`defineButtons` wird in der `boot.php` in einer schleife aufgerufen.

durch die Änderung wird die config jetzt nur noch 1x von der platte gelesen.

net effect:
27% weniger rendertime

Profile:
https://blackfire.io/profiles/compare/5a321efa-5705-4f08-8365-56d847af3411/graph
Link ist nur 30 Tage gültig.