### PR TITLE
Patch für PHP >= 7.1.0

### DIFF
--- a/vendor/php-textile/src/Netcarver/Textile/Parser.php
+++ b/vendor/php-textile/src/Netcarver/Textile/Parser.php
@@ -2029,7 +2029,7 @@ class Parser
 
     protected function parseAttribsToArray($in, $element = '', $include_id = true, $autoclass = '')
     {
-        $style = '';
+        $style = array();
         $class = '';
         $lang = '';
         $colspan = '';


### PR DESCRIPTION
Seit PHP 7.1.0 wirft die Anwendung des leeren Index-Operators auf eine Zeichenkette einen fatalen Fehler. Zuvor wurde die Zeichenkette stillschweigend in ein Array umgewandelt. Das hier:
`h1=. Zentrierte Überschrift`
lässt unter einer aktuellen PHP Version Redaxo komplett abschmieren. Ein entsprechendes [Issue](https://github.com/textile/php-textile/issues/175) inkl PR dümpelt im Vendor Repo seit April rum, aber es passiert nix. Ich denke deswegen es wär legitim, das hier einzubauen.