### PR TITLE
Behoben: DropDownMenü erscheint transparent; z-index ergänzt

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -23,6 +23,7 @@
 	position:absolute;
 	left:0px;
 	top:34px;
+    z-index: 1;
 }
 
 .markItUpContainer .markItUpHeader > ul > li.markItUpDropMenu > ul > li {


### PR DESCRIPTION
In der Button-Leiste erscheint das Drop-Down-Menü transparent. Bei mehrzeiligen Button-Leisten sind also der Text eines Menü-Items und der eigentlich darunter liegende Button zusammen sichtbar. Das verringert die Lesbarkeit etwas. 

<img width="316" alt="grafik" src="https://user-images.githubusercontent.com/10065904/37480936-c5289896-2880-11e8-8650-b06709c59977.png">

Durch hinzufügen eines `z-index: 1;` im css wird das Problem behoben.
https://github.com/FriendsOfREDAXO/markitup/blob/master/assets/style.css#L20
```
.markItUpContainer .markItUpHeader > ul > li.markItUpDropMenu ul {
	border-top: 1px solid #9ca5b2;
	display:none;
	position:absolute;
	left:0px;
	top:34px;
        z-index: 1;
}
```