### PR TITLE
Textile Skript

### DIFF
--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -192,7 +192,7 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 			
 			$.markItUp({
 				openWith: '"',
-				closeWith: ' ('+filename+')":/media/'+filename
+				closeWith: '":/media/'+filename
 			});
 		});
 	}
@@ -205,7 +205,7 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 			
 			$.markItUp({
 				openWith: '"',
-				closeWith: ' ('+linktext+')":'+linkurl
+				closeWith: '":'+linkurl
 			});
 		});
 	}


### PR DESCRIPTION
- interne Links: es wird nicht mehr automatisch "Artikelname [ArtikelID]" alt title Attribut eingefügt
- media Links: es wird nicht mehr automatisch "Dateiname" als title Attribut eingefügt