### PR TITLE
New Feature: Links to YForm-tables incl. support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## **11.08.2020 Version 3.4.0**
+
+New Features:
+
+- Links to YForm-tables (@christophboecker)
+    - optional button for a dropdown-menu with entries per linked YForm table
+        ...,yform[tabel1|table2],...
+    - Record-selection via default popup-window from YForm.
+    - link-schema: yform:tablename/data_id ( -> yform:rex_table1/123 )
+    - link-translation by individual callback
+    - inUse-Funktion
+    - for details activate plugin "Documentation" and view page "Editor integrieren"
+
+
+Enhancements:
+- changelog implemented
+
+
+## **09.08.2020 Version 3.3.4**
+
+Enhancements:
+- Bump to textile 3.7.6 (@schuer)

--- a/assets/scripts.js
+++ b/assets/scripts.js
@@ -19,11 +19,39 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 	function btnImageCallbackInsert() {
 		alert('Module-Input is misconfigured, please use the example!');
 	}
-	
+
 	function btnLinkInternalCallbackInsert() {
 		alert('Module-Input is misconfigured, please use the example');
 	}
 //End - temporary functions to prevent errors
+
+// Support for YForm; provide necessary callback-helper
+function markitupYformConnectionCreate( container ) {
+    let $yform = {};
+    // id erzeugen
+    $yform.id = Math.floor( Math.random( ) * 1000000000000 + 1000000000000 );
+    // Input 1 erzeugen: YFORM_DATASET_SELECT
+    $yform.SELECT = document.createElement( 'input' );
+    $yform.SELECT.classList.add('hidden');
+    $yform.SELECT.id = 'YFORM_DATASET_SELECT_' + $yform.id;
+    container.append( $yform.SELECT );
+    // Input 2 erzeugen: YFORM_DATASET_FIELD
+    $yform.FIELD = document.createElement( 'input' );
+    $yform.FIELD.classList.add('hidden');
+    $yform.FIELD.id = 'YFORM_DATASET_FIELD_' + $yform.id;
+    container.append( $yform.SELECT );
+    return $yform;
+}
+
+function markitupYformOpen( id, tablename, data_id ){
+    newWindow(
+        'y'+id,
+        'index.php?page=yform/manager/data_edit&table_name='+tablename+'&rex_yform_manager_popup=1&func=edit&data_id='+data_id,
+        1200,
+        Math.max(screen.height*0.75,800),
+//        ',status=no,resizable=yes,nav=no'
+    );
+}
 
 //Start - functions for markdown
 	function btnMarkdownMediaCallback () {
@@ -31,13 +59,13 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 		$(mediapool).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
-			
+
 			$.markItUp({
 				openWith: '!['+filename+'](index.php?rex_media_type=markitupImage&rex_media_file='+filename+')'
 			});
 		});
 	}
-	
+
 	function btnMarkdownLinkExternalCallback (h) {
 		var linktext = h.selection;
 		if (linktext == '') {
@@ -45,38 +73,38 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 				return;
 			}
 		}
-		
+
 		if (!(linkurl = prompt(markitupLanguagestrings[currentLanguage]['linkurl'], 'http://'))) {
 			return;
 		}
-		
+
 		return '['+linktext+']('+linkurl+')';
 	}
-	
+
 	function btnMarkdownLinkMediaCallback () {
 		var mediapool = openMediaPool('markitup_link');
 		$(mediapool).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
-			
+
 			$.markItUp({
 				openWith: '['+filename+'](/media/'+filename+')'
 			});
 		});
 	}
-	
+
 	function btnMarkdownLinkInternalCallback () {
 		var linkMap = openLinkMap();
 		$(linkMap).on('rex:selectLink', function (event, linkurl, linktext) {
 			event.preventDefault();
 			linkMap.close();
-			
+
 			$.markItUp({
 				openWith: '['+linktext+']('+linkurl+')'
 			});
 		});
 	}
-	
+
 	function btnMarkdownLinkMailtoCallback (h) {
 		var linktext = h.selection;
 		if (linktext == '') {
@@ -84,46 +112,46 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 				return;
 			}
 		}
-		
+
 		if (!(emailaddress = prompt(markitupLanguagestrings[currentLanguage]['linkemailaddress']))) {
 			return;
 		}
-		
+
 		return '['+linktext+'](mailto:'+emailaddress+')';
 	}
-	
+
 	function btnMarkdownTableCallback (h) {
 		if (!(cols = prompt(markitupLanguagestrings[currentLanguage]['tablecolumns']))) {
 			return;
 		}
-		
+
 		if (!(rows = prompt(markitupLanguagestrings[currentLanguage]['tablerows']))) {
 			return;
 		}
-		
+
 		html = '';
-		
+
 		for (r = 0; r < rows; r++) {
 			for (c = 0; c < cols; c++) {
 				html += '| ABC ';
 			}
 			html += '|\n';
 		}
-		
+
 		return html;
 	}
-	
+
 	function btnMarkdownOrderedlistCallback (h) {
 		var selection = h.selection;
-		
+
 		if (selection != '') {
 			var lines = selection.split(/\r?\n/);
 			var r = "";
 			for (var i=0; i < lines.length; i++) {
 				line = lines[i];
-				
+
 				r = r + (i+1) + '. ' + line;
-				
+
 				if (i != lines.length - 1) {
 					r += "\n";
 				}
@@ -133,18 +161,18 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 			return;
 		}
 	}
-	
+
 	function btnMarkdownUnorderedlistCallback (h) {
 		var selection = h.selection;
-		
+
 		if (selection != '') {
 			var lines = selection.split(/\r?\n/);
 			var r = "";
 			for (var i=0; i < lines.length; i++) {
 				line = lines[i];
-				
+
 				r = r + "- " + line;
-				
+
 				if (i != lines.length - 1) {
 					r += "\n";
 				}
@@ -154,6 +182,30 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 			return;
 		}
 	}
+
+    function btnMarkdownYformCallback( h, table ){
+        let markItUp = $.markItUp;
+        if( !markitup._yform ) markitup._yform = {};
+        let $yform = markitup._yform[yform];
+        if( !$yform ) {
+            $yform = markitupYformConnectionCreate( markitup.focused.closest('.markitup_markdown') );
+            markitup._yform[yform] = $yform;
+        }
+        $yform.done = false;
+        var dokument = openYFormDataset($yform.id, table+'.id', 'index.php?page=yform/manager/data_edit&table_name=rex_kv30_'+table );
+
+        $(dokument).on('rex:YForm_selectData', function (event, id) {
+            event.preventDefault();
+            if( $yform.done ) return;
+            $.markItUp({
+                openWith: '[',
+                closeWith: '](yform:'+table+'/'+id+')'
+            });
+            $yform.done = true;
+        });
+
+
+    }
 //End - functions for markdown
 
 //Start - functions for textile
@@ -162,13 +214,13 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 		$(mediapool).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
-			
+
 			$.markItUp({
 				openWith: '!index.php?rex_media_type=markitupImage&rex_media_file='+filename+'('+filename+')!'
 			});
 		});
 	}
-	
+
 	function btnTextileLinkExternalCallback (h) {
 		var linktext = h.selection;
 		if (linktext == '') {
@@ -176,40 +228,43 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 				return;
 			}
 		}
-		
+
 		if (!(linkurl = prompt(markitupLanguagestrings[currentLanguage]['linkurl'], 'http://'))) {
 			return;
 		}
-		
+
 		return '"'+linktext+'":'+linkurl;
 	}
-	
+
+
 	function btnTextileLinkMediaCallback () {
+
 		var mediapool = openMediaPool('markitup_link');
 		$(mediapool).on('rex:selectMedia', function (event, filename) {
 			event.preventDefault();
 			mediapool.close();
-			
+
 			$.markItUp({
 				openWith: '"',
 				closeWith: '":/media/'+filename
 			});
 		});
 	}
-	
+
+
 	function btnTextileLinkInternalCallback () {
 		var linkMap = openLinkMap();
 		$(linkMap).on('rex:selectLink', function (event, linkurl, linktext) {
 			event.preventDefault();
 			linkMap.close();
-			
+
 			$.markItUp({
 				openWith: '"',
 				closeWith: '":'+linkurl
 			});
 		});
 	}
-	
+
 	function btnTextileLinkMailtoCallback (h) {
 		var linktext = h.selection;
 		if (linktext == '') {
@@ -217,11 +272,11 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 				return;
 			}
 		}
-		
+
 		if (!(emailaddress = prompt(markitupLanguagestrings[currentLanguage]['linkemailaddress']))) {
 			return;
 		}
-		
+
 		return '"'+linktext+'":mailto:'+emailaddress;
 	}
 
@@ -229,34 +284,34 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 		if (!(cols = prompt(markitupLanguagestrings[currentLanguage]['tablecolumns']))) {
 			return;
 		}
-		
+
 		if (!(rows = prompt(markitupLanguagestrings[currentLanguage]['tablerows']))) {
 			return;
 		}
-		
+
 		html = '';
-		
+
 		for (r = 0; r < rows; r++) {
 			for (c = 0; c < cols; c++) {
 				html += '|ABC';
 			}
 			html += '|\n';
 		}
-		
+
 		return html;
 	}
-	
+
 	function btnTextileOrderedlistCallback (h) {
 		var selection = h.selection;
-		
+
 		if (selection != '') {
 			var lines = selection.split(/\r?\n/);
 			var r = "";
 			for (var i=0; i < lines.length; i++) {
 				line = lines[i];
-				
+
 				r = r + "# " + line;
-				
+
 				if (i != lines.length - 1) {
 					r += "\n";
 				}
@@ -266,18 +321,18 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 			return;
 		}
 	}
-	
+
 	function btnTextileUnorderedlistCallback (h) {
 		var selection = h.selection;
-		
+
 		if (selection != '') {
 			var lines = selection.split(/\r?\n/);
 			var r = "";
 			for (var i=0; i < lines.length; i++) {
 				line = lines[i];
-				
+
 				r = r + "* " + line;
-				
+
 				if (i != lines.length - 1) {
 					r += "\n";
 				}
@@ -287,4 +342,49 @@ markitupLanguagestrings['en']['tablerows'] = 'How many rows?';
 			return;
 		}
 	}
+
+    function btnTextileUnorderedlistCallback (h) {
+        var selection = h.selection;
+
+        if (selection != '') {
+            var lines = selection.split(/\r?\n/);
+            var r = "";
+            for (var i=0; i < lines.length; i++) {
+                line = lines[i];
+
+                r = r + "* " + line;
+
+                if (i != lines.length - 1) {
+                    r += "\n";
+                }
+            }
+            return r;
+        } else {
+            return;
+        }
+    }
+
+    function btnTextileYformCallback( h, table ){
+        let markitup = $.markItUp;
+        if( !markitup._yform ) markitup._yform = {};
+        let $yform = markitup._yform[table];
+        if( !$yform ) {
+            $yform = markitupYformConnectionCreate( markitup.focused.closest('.markitup_textile') );
+            markitup._yform[table] = $yform;
+        }
+        $yform.done = false;
+        var dokument = openYFormDataset($yform.id, table+'.id', 'index.php?page=yform/manager/data_edit&table_name='+table );
+
+        $(dokument).on('rex:YForm_selectData', function (event, id) {
+            event.preventDefault();
+            if( $yform.done ) return;
+            $.markItUp({
+                openWith: '"',
+                closeWith: '":yform:'+table+'/'+id
+            });
+            $yform.done = true;
+        });
+
+
+    }
 //End - functions for textile

--- a/assets/style.css
+++ b/assets/style.css
@@ -185,6 +185,10 @@
 	content: "\f0cb";
 }
 
+.markItUpContainer .markItUpHeader > ul > li.tuedel > a:before {
+	content: "\f10d\f10e";
+}
+
 .markItUpContainer .markItUpHeader > ul > li.paragraph > a:before {
 	content: "\f1dd";
 }
@@ -217,6 +221,10 @@
 
 .markItUpContainer .markItUpHeader > ul > li.unorderedlist > a:before {
 	content: "\f0ca";
+}
+
+.markItUpContainer .markItUpHeader > ul > li.yform > a:before {
+	content: "\f1c0";
 }
 
 .markItUpContainer .markItUpHeader > ul > li.markItUpSeparator {

--- a/assets/style.css
+++ b/assets/style.css
@@ -185,10 +185,6 @@
 	content: "\f0cb";
 }
 
-.markItUpContainer .markItUpHeader > ul > li.tuedel > a:before {
-	content: "\f10d\f10e";
-}
-
 .markItUpContainer .markItUpHeader > ul > li.paragraph > a:before {
 	content: "\f1dd";
 }

--- a/config.yml
+++ b/config.yml
@@ -283,3 +283,7 @@ unorderedlist:
     replaceWith:
         markdown: "function(h) {return btnMarkdownUnorderedlistCallback(h);}"
         textile: "function(h) {return btnTextileUnorderedlistCallback(h);}"
+
+yform:
+    name: profiles_buttons_yform
+    className: yform

--- a/functions/cache_markitup_profiles.php
+++ b/functions/cache_markitup_profiles.php
@@ -88,6 +88,7 @@ function markitup_cache_defineButtons($type, $profileButtons, $languageSet) {
     $buttonString = '';
     $profileButtons = explode(',', $profileButtons);
     foreach ($profileButtons as $profileButton) {
+
         $profileButton = trim($profileButton);
         $options = [];
 
@@ -122,6 +123,17 @@ function markitup_cache_defineButtons($type, $profileButtons, $languageSet) {
                         $options[] = $parameter;
                     }
                 }
+            } elseif( $profileButton == 'yform' ) {
+                // yform[tablename|...]
+                $data = [];
+                foreach ($parameters as $table) {
+                    $options[] = $table;
+                    $data[$table] = [
+                        'name' => 'profiles_buttons_yform_option_'.$table,
+                        'replaceWith' => [ $type => 'function(h) {return btn'.ucfirst($type).'YformCallback(h,"'.rex::getTable($table).'");}']
+                    ];
+                }
+                $markItUpButtons[$profileButton]['children'] = $data;
             } else {
                 foreach ($parameters as $parameter) {
                     if (strpos($parameter, '=') !== false) {

--- a/functions/cache_markitup_profiles.php
+++ b/functions/cache_markitup_profiles.php
@@ -133,6 +133,7 @@ function markitup_cache_defineButtons($type, $profileButtons, $languageSet) {
                         'replaceWith' => [ $type => 'function(h) {return btn'.ucfirst($type).'YformCallback(h,"'.rex::getTable($table).'");}']
                     ];
                 }
+                if( !rex_i18n::hasMsg('markitup_'.$data[$table]['name']) ) rex_i18n::addMsg('markitup_'.$data[$table]['name'],$table);
                 $markItUpButtons[$profileButton]['children'] = $data;
             } else {
                 foreach ($parameters as $parameter) {

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -87,6 +87,10 @@ markitup_profiles_buttons_underline = Unterstrichen
 markitup_profiles_buttons_underline_description = Unterstreicht den markierten Text
 markitup_profiles_buttons_unorderedlist = Unsortierte Liste
 markitup_profiles_buttons_unorderedlist_description = Fügt eine unsortierte Liste ein
+markitup_profiles_buttons_yform = Datenbank
+markitup_profiles_buttons_yform_description1 = YForm-Link => yform[name/tabellenname|...]
+markitup_profiles_buttons_yform_description2 = Beim Tabellennamen das "rex_" weglassen!
+markitup_profiles_buttons_yform_description3 = In eigener lang-Datei "markitup_profiles_buttons_yform_option_name" einfügen
 
 #subpage snippets
 markitup_snippets = Snippets

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -87,6 +87,10 @@ markitup_profiles_buttons_underline = Underlined
 markitup_profiles_buttons_underline_description = Underlines the highlighted text
 markitup_profiles_buttons_unorderedlist = Unordered list
 markitup_profiles_buttons_unorderedlist_description = Inserts an unordered list
+markitup_profiles_buttons_yform = Database
+markitup_profiles_buttons_yform_description1 = YForm-Link => yform[name/tablename|...]
+markitup_profiles_buttons_yform_description2 = Use tablename without leading "rex_"!
+markitup_profiles_buttons_yform_description3 = Put an entry in your .lang-file corresponding to name: "markitup_profiles_buttons_yform_option_name"
 
 #subpage snippets
 markitup_snippets = Snippets
@@ -108,7 +112,7 @@ markitup_snippets_label_description = Descriptions
 
 markitup_validate_empty = Field "{0}" may not be empty.
 markitup_validate_unique = The value for "{0}" needs to be unique.
-markitup_validate_invalid = Invalid value for "{0}". 
+markitup_validate_invalid = Invalid value for "{0}".
 
 #permissions
 perm_general_markitup[] = Permissions for the MarkItUp-Addon

--- a/lib/class.markitup.php
+++ b/lib/class.markitup.php
@@ -1,6 +1,9 @@
 <?php
     class markitup
     {
+
+        static $yform_callback = null;
+
         public static function insertProfile($name, $description = '', $type = '', $minheight = '300', $maxheight = '800', $urltype = 'relative', $markitupButtons = '')
         {
             $sql = rex_sql::factory();
@@ -28,7 +31,7 @@
         public static function profileExists($name)
         {
             $sql = rex_sql::factory();
-            $profile = $sql->setQuery("SELECT `name` FROM `".rex::getTablePrefix()."markitup_profiles` WHERE `name` = ".$sql->escape($name)."")->getArray();
+            $profile = $sql->setQuery("SELECT `name` FROM `".rex::getTable('markitup_profiles')."` WHERE `name` = ".$sql->escape($name)."")->getArray();
             unset($sql);
 
             if (!empty($profile)) {
@@ -105,15 +108,113 @@
                 case 'markdown':
                     require_once(rex_path::addon('markitup', 'lib/class.markitup_markdown.php')); //todo: use $this
                     $parser = new markitup_markdown();
-                    return $parser->text($content);
+                    return self::replaceYFormLink( $parser->text($content) );
                 break;
                 case 'textile':
                     require_once(rex_path::addon('markitup', 'lib/class.markitup_textile.php')); //todo: use $this
                     $parser = new markitup_textile();
-                    return $parser->custom_parse($content);
+                    return self::replaceYFormLink( $parser->custom_parse($content) );
                 break;
             }
 
             return false;
         }
+
+        public static function replaceYFormLink( $content )
+        {
+            $callback = function( $link ) { return 'javascript:void();'; };
+            if( rex::isBackend() && rex::getUser() )
+            {
+                if( rex::getUser() )
+                {
+                    $callback = self::$yform_callback ?: 'self::createYFormLink';
+                }
+            }
+            elseif( self::$yform_callback )
+            {
+                $callback = self::$yform_callback;
+            }
+            return preg_replace_callback (
+                '/yform:(?<table_name>[a-z0-9_]+)\/(?<id>\d+)/' ,
+                $callback,
+                $content );
+        }
+
+        public static function createYFormLink( $link )
+        {
+            return 'javascript:markitupYformOpen( \''.mt_rand(1000000,999999999).'\', \''.$link[1].'\', \''.$link[2].'\' );';
+        }
+
+        public static function yformLinkInUse( $table_name, $data_id, $tableset=null, $fullResult=false )
+        {
+            $sql = rex_sql::factory();
+
+            // $tableset = null     =>  Alle Tabellen betrachten
+            // $tableset = 1        =>  Nur Core-Tabellen article, article_slice und media betrachten
+            // $tableset = 2        =>  Nur YForm-Tabellen betrachten
+            // $tableset = [...]    =>  Nur die angegebenen Tabellen betrachten
+            if( null === $tableset )
+            {
+                $tableset = $sql->getTables();
+            }
+            elseif( is_array($tableset) )
+            {
+                // void
+            }
+            elseif( 1 === $tableset )
+            {
+                $tableset = ['rex_article','rex_article_slice','rex_media'];
+            }
+            elseif( 2 === $tableset || 3 == $tableset )
+            {
+                try {
+                    $tableset = $sql->getArray('SELECT id, table_name FROM rex_yform_fields',[],PDO::FETCH_KEY_PAIR);
+                } catch (\Exception $e) {
+                    $tableset = []; // insb. falls es rex_yform_fields nicht gibt ($tableset = [frei angegeben])
+                }
+                if( 3 == $tableset )
+                {
+                    $tableset[] = 'rex_article';
+                    $tableset[] = 'rex_article_slice';
+                    $tableset[] = 'rex_media';
+                }
+            }
+            else {
+                $tableset = [];
+            }
+
+            // Wenn $fullResult angefordert ist, werden alle Tabellen durchlaufen und je Tabelle mit
+            // gefundenem Link die Satznummern zurückgemeldet.
+            // Ansonsten wird beim ersten Fund beendet
+            $limit = true !== $fullResult ? 'LIMIT 1' : '';
+            $result = [];
+
+            foreach( $tableset as $table ){
+
+                // Alle Felder ermitteln, deren Typen mit varchar(xx) oder text sind.
+                try {
+                    $qry = 'SHOW FIELDS FROM '.$sql->escapeIdentifier($table).' WHERE Type LIKE \'varchar%\' OR Type = \'text\'';
+                    $fields = array_column( $sql->getArray( $qry ), 'Field');
+                    if( !$fields ) continue;
+                } catch (\Exception $e) {
+                    continue; // Falls es die Tabelle nicht gibt; relevant für
+                }
+
+                // Je Feld die Abfrage aufbauen, ob der Link dort vorkommt.
+                foreach( $fields as &$field )
+                {
+                    $field = 'LOCATE(\'yform:'.$table_name.'/'.$data_id.'\','.$sql->escapeIdentifier($field).')';
+                }
+                $qry = 'SELECT id FROM '.$sql->escapeIdentifier($table).' WHERE '.implode(' OR ',$fields ).$limit;
+                if( $inUse = $sql->getArray( $qry ) )
+                {
+                    if( $limit ) return true;
+                    $result[$table] = array_column( $inUse, 'id' );
+                }
+            }
+
+            if( $result ) return $result;
+            return false;
+        }
+
     }

--- a/lib/class.markitup_textile.php
+++ b/lib/class.markitup_textile.php
@@ -4,30 +4,32 @@
         require_once(rex_path::addon('markitup', 'vendor/php-textile/src/Netcarver/Textile/DataBag.php')); //todo: use $this
         require_once(rex_path::addon('markitup', 'vendor/php-textile/src/Netcarver/Textile/Tag.php')); //todo: use $this
     }
-    
+
     class markitup_textile extends Netcarver\Textile\Parser
     {
         private static $instances = [];
-        
+
         public function __construct($doctype = 'xhtml')
         {
             parent::__construct($doctype);
             $this->unrestricted_url_schemes[] = 'redaxo';
             $this->restricted_url_schemes[] = 'redaxo';
+            $this->unrestricted_url_schemes[] = 'yform';
+            $this->restricted_url_schemes[] = 'yform';
         }
-        
+
         public static function custom_parse($code, $restricted = false, $doctype = 'xhtml')
         {
             $instance = self::getInstance($doctype);
             return $restricted ? $instance->setRestricted(true)->parse($code) : $instance->setRestricted(false)->parse($code);
         }
-        
+
         private static function getInstance($doctype = 'xhtml')
         {
             if (!isset(self::$instances[$doctype])) {
                 self::$instances[$doctype] = new markitup_textile($doctype);
             }
-            
+
             return self::$instances[$doctype];
         }
     }

--- a/pages/profiles.php
+++ b/pages/profiles.php
@@ -186,6 +186,11 @@
 							'<br>'.
 							'<b>unorderedlist</b><br>'.
 							$this->i18n('profiles_buttons_unorderedlist_description').'<br>'.
+                            '<br>'.
+                            '<b>YForm-Tabelle</b><br>'.
+                            $this->i18n('markitup_profiles_buttons_yform_description1').'<br>'.
+                            $this->i18n('markitup_profiles_buttons_yform_description2').'<br>'.
+                            $this->i18n('markitup_profiles_buttons_yform_description3').'<br>'.
 							'
 						</div>
 					</dd>

--- a/plugins/documentation/docs/de_de/howto_integration.md
+++ b/plugins/documentation/docs/de_de/howto_integration.md
@@ -4,9 +4,12 @@ Mit der Installation des AddOns markitUp! stehen Dir die default-Profile für ma
 
 Für eine bedienerfreundliche Nutzung im System empfehlen wir Dir noch 3 Schritte für die Integration in REX:
 * [Einschränken der Funktionen in den Editoren](#editoren)
-* [Editoren um Textbausteine erweitern](#textbausteine)
 * [Integration markdown](#markdown)
 * [Integration textile](#textile)
+
+Weitere Informationen und Features:
+* [Editoren um Textbausteine erweitern](#textbausteine)
+* [Editoren mit Links auf YForm-Tabellen](#yform)
 * [Weitere Modul-Beispiele](#beispiele)
 
 
@@ -19,28 +22,6 @@ Beispiel für einen minimalisierten textile-Editor:
 
 	groupheading[2|3|4|5|6], grouplink[internal|external|mailto|file], unorderedlist, orderedlist, sup, sub
 
-
-<a name="textbausteine"></a>
-### Editoren um Textbausteine erweitern
-
-Über die Clip-Funktion können eigene Textbausteine im Editor bereitgestellt werden. Hier ein Basisbeispiel aus dem mitgelieferten Profil "markdown_full":
-
-    bold,code,clips[Snippetname1=Snippettext1|Snippetname2=Snippettext2],deleted,emaillink, ....
-
-![snippets](snippet.jpg)
-
-Klick auf "Snippetname1" würde an der Cursorposition den Text "Snippettext1" einfügen. Komplexe oder größere Textbausteine sprengen schnell den Rahmen des Möglichen,
-wenn man sie in der Profil-Konfiguration einbaut. Ergänzend kann in der Tabelle "Snippets" eine Textbausteinbibliothek erfasst werden.
-
-Zuerst wird in der Snippet-Liste nach dem Textbaustein "Snippettext1" (um beim Beispiel zu bleiben) gesucht. Gibt es ihn, wird er in den Text eingebaut. Gibt es ihn nicht, wird wie zuvor "Snippettext1" in den Text eingebaut.
-
-Es kann mehrere Snippets gleichen Namens geben für unterschiedliche Backendsprachen. Per Default gilt ein Textbaustein "für alle Sprachen". Wenn zu einem Snippettextnamen
-mehrere Sprachvarianten existieren, wird wie folgt ausgewählt:
-
-1. die Variante der aktuell eingestellten Backendsprache. Wenn nicht existent ...
-2. ... die Variante "für alle Sprachen". Wenn nicht existent ...
-3. ... die Variante einer der Fallback-Sprachen gem. Systemkonfiguration. Wenn nicht existent ...
-4. ... wird der Snippettextname als Text übernommen.
 
 
 <a name="markdown"></a>
@@ -259,6 +240,154 @@ Die entsprechende css-Klasse für den Editor vergibst Du unter [Profile](/redaxo
 &uarr; [zurück zur Übersicht](#top)
 
 
+<a name="textbausteine"></a>
+### Editoren um Textbausteine erweitern
+
+Über die Clip-Funktion können eigene Textbausteine im Editor bereitgestellt werden. Hier ein Basisbeispiel aus dem mitgelieferten Profil "markdown_full":
+
+    bold,code,clips[Snippetname1=Snippettext1|Snippetname2=Snippettext2],deleted,emaillink, ....
+
+![snippets](snippet.jpg)
+
+Klick auf "Snippetname1" würde an der Cursorposition den Text "Snippettext1" einfügen. Komplexe oder größere Textbausteine sprengen schnell den Rahmen des Möglichen,
+wenn man sie in der Profil-Konfiguration einbaut. Ergänzend kann in der Tabelle "Snippets" eine Textbausteinbibliothek erfasst werden.
+
+Zuerst wird in der Snippet-Liste nach dem Textbaustein "Snippettext1" (um beim Beispiel zu bleiben) gesucht. Gibt es ihn, wird er in den Text eingebaut. Gibt es ihn nicht, wird wie zuvor "Snippettext1" in den Text eingebaut.
+
+Es kann mehrere Snippets gleichen Namens geben für unterschiedliche Backendsprachen. Per Default gilt ein Textbaustein "für alle Sprachen". Wenn zu einem Snippettextnamen
+mehrere Sprachvarianten existieren, wird wie folgt ausgewählt:
+
+1. die Variante der aktuell eingestellten Backendsprache. Wenn nicht existent ...
+2. ... die Variante "für alle Sprachen". Wenn nicht existent ...
+3. ... die Variante einer der Fallback-Sprachen gem. Systemkonfiguration. Wenn nicht existent ...
+4. ... wird der Snippettextname als Text übernommen.
+
+&uarr; [zurück zur Übersicht](#top)
+
+<a name="yform"></a>
+### Links auf YForm-Tabellen einfügen
+
+> MarkItUp greift nicht direkt auf YForm zu. Somit ist YForm auch keine Installationsvorrausetzung. Wenn dieser Link-Mechanismus für YForm genutzt werden soll,
+muss YForm auch verfügbar sein. Das liegt in der Verantwortung des Entwicklers / Administrators
+
+Über die YForm-Funktion können beliebige YForm-Tabellen als Popup-Fenster aufgerufen, ein Eintrag ausgewählt und als Link in den Text eingebaut werden.
+Hier ein Basisbeispiel für die Tabellen
+- rex_shop_artikel
+- rex_shop_kunde
+- rex_shop_bestellung
+
+Das einleitende "rex_" wird weggelassen; daraus ergibt sich der Name des Eintrags im Profil:
+
+    ...,yform[shop_artikel|shop_kunde|shop_bestellung],...
+
+Aus diesem Profileintrag wird ein Dropdown-Menu erstellt. Klickt man den Eintrag an, wird ein Auswahl-Popup der Tabelle "rex_xxx" angezeigt, wobei xxx der jeweilige Name des Eintrags ist.
+
+Der Name wird über i18n in den angezeigten Text übersetzt. Dazu muss ein .lang-Eintrag angelegt werden, der folgenden Aufbau hat:
+```
+profiles_buttons_yform_option_xxx
+```
+wobei wiederum xxx der Name aus dem Profil ist bzw. der Tabellenname ohne führendes "rex_".
+
+Beispiel:
+```
+profiles_buttons_yform_option_artikel = Artikel
+profiles_buttons_yform_option_kunden = Kunden
+profiles_buttons_yform_option_bestellung = Bestellung
+```
+
+Hat man den Datensatz ausgewählt, wird ein Link-Eintrag im Editorfeld erzeugt, dessen URL dem Schema `yform:rex_xxx/nnn` folgt. Dabei ist xxx der Name des Eintrags und nnn die Satznummer (Feld `id`) des ausgewählten Datensatzes.
+
+```
+/yform:rex_shop_artikel/22
+```
+
+Für die Ausgabe werden die Pseudo-URLs in eine konkrete Url umgewandelt. Dabei ist zu beachten:
+
+#### URL-Auflösung im Frondend
+
+Per default werden die Links umgewandelt in 'javascript&colon;void();', also neutralisiert.
+
+Über eine eigenen Callback-Funktion können die individuellen Links erzeugt werden. Die Callback-Methode erhält ein
+preg-match-Array mit den Elementen `table_name` und `id`. Die Funktion muss daraus die URL aufbauen und den String
+mit Return zurückmelden.
+
+Da nur eine Funktion zugewiesen werden kann, muss sie ggf. zwischen Frontend und Backend
+unterscheiden und auch ggf. Berechtigungsprüfungen durchführen.
+
+#### URL-Auflösung im Backend
+
+Im Backend wird zumindest verlangt, dass ein Benutzer angemeldet ist. Ansonsten werden die Links neutralisiert.
+
+Im Backend werden die Links in JS-Aufrufe umgewandelt: 'javascript&colon;markitupYformOpen(nummer,tablename,id);'. Damit wird der Datensatz in einem neuen Edit-Fenster angezeigt.
+- Die Nummer ist zufällig erzeugt und benennt das Fenster
+- Der Tabellenname ist aus dem Link entnommen
+- Die Satznummer ist aus dem Link entnommen.
+
+Alternativ kann der Link auch über die Callback-Funktion erzeugt werden.
+
+#### URL-Auflösung mit Callback
+
+Das Beispiel zeigt gleich zwei Punkte:
+- Die Callback-Funktion wird über Zuweisung an `markitup::$yform_callback` festgelegt.
+- Die Funktion erzeugt im Backend den Standard-Link und im Frontend einen individuellen.
+- Wenn keine Berechtigung im Frontend vorliegt, wird ein Null-Link erzeugt.
+
+```PHP
+markitup::$yform_callback = function ($link) {
+    if( rex:isBackend() ) {
+        return markitup::createYFormLink( $link );
+    }
+    if( .... autorisiert ....) return 'http://mydomain/daten/'.$link['table_name'].'/edit/'.$link['id'];
+    return rex_article::getNotfoundArticle()->getUrl();
+};
+```
+
+#### Id is in Use - Löschen absichern
+
+Es steht eine Funktion zur Verfügung, mit der Yform-Links in den Textfeldern überprüft werden können
+
+```php
+markitup::yformLinkInUse( $table_name, $data_id, $tableset=null, $fullResult=false )
+```
+Die Funktion überprüft für die angegebenen Tabllen in den Feldern vom Typ `text` und vom Typ `varchar...`, ob
+in ihnen der zu prüfende Link vorkommt.  
+
+Beispiel:
+- Aus der YForm-Tabelle `rex_shop_kunde` soll der Datensatz `123` wird gelöscht werden.
+- Referenzen kommen nur in den Core-Tabellen (Artikel, Media) vor.
+- Gesucht wird nach dem Eintrag `yform:$table_name/$data_id`, also hier: `yform:rex_shop_kunde/123`
+
+| Parameter | Erklärung | Beispiel |
+|--|--|--|
+| $table_name | Der Name der Tabelle, deren Eintrag geprüft wird | rex_shop_kunde |
+| $data_id | Die ID des Datensatzes, der geprüft wird | 123 |
+| $tableset | Die Liste der Tabellen, in denen nach dem Link gesucht wird | 1 |
+| $fullResult | wenn TRUE werden die IDs aller gefundenen referenzen zurückgemeldet, sonst nur TRUE/FALSE |  |
+
+
+Für `$tableset` gibt es die Varianten
+- null => **Alle** Tabellen der Datenbank durchsuchen (sicher, aber aufwendig und daher langsam)
+- 1 => Core-Tabellen rex_article, rex_article_slice und rex_media durchsuchen
+- 2 => YForm-Tabellen durchsuchen
+- 3 => Kombination aus 1 und 2
+- `['tabelle_1',...]` = nur die Liste der angegebenen Tabellen durchsuchen.
+- alle anderen Eingaben => keine Suche, Rückmeldung ist `false` = nicht in Benutzung
+
+Im Normalfall bricht die Funktion nach dem ersten gefundenen Eintrag bereits mit TRUE ab.
+Mit `$fullResult = true` wird stets eine Suche über alle angegebenen Tabellen durchgeführt und alle
+gefundenen Einträge als Array der Satznummern (id) zurückgemeldet.
+
+Die Funktion kann z.B. über den Extension-Point `YFORM_DATA_DELETE` genutzt werden; im Beispiel wird die YForm-Tabelle `rex_shop_kunde` überwacht:
+
+```php
+\rex_extension::register('YFORM_DATA_DELETE', function( \rex_extension_point $ep ){
+    $table_name = $ep->getParam('table')->getTablename();
+    if( 'rex_shop_kunde' !== $table_name ) return true;
+    return !markitup::yformLinkInUse( $table_name, $ep->getParam('data_id'), 1 );
+});
+```
+
+&uarr; [zurück zur Übersicht](#top)
 
 <a name="beispiele"></a>
 ## Weitere Modul-Beispiele

--- a/plugins/documentation/package.yml
+++ b/plugins/documentation/package.yml
@@ -1,5 +1,5 @@
 package: markitup/documentation
-version: '1.0.1'
+version: '1.1.0'
 author: 'Friends Of REDAXO'
 supportpage: https://github.com/FriendsOfREDAXO/markitup
 


### PR DESCRIPTION
- Links to YForm-tables 
    - optional button for a dropdown-menu with entries per linked YForm table
        ...,yform[tabel1|table2],...
    - Record-selection via default popup-window from YForm.
    - link-schema: yform:tablename/data_id ( -> yform:rex_table1/123 )
    - link-translation by individual callback
    - inUse-Funktion
    - for details activate plugin "Documentation" and view page "Editor integrieren"

Bitte mal testen vor Freigabe, 2-Aupen-Prinzip klappt nur in Ausnahmefällen

<img width="400" alt="grafik" src="https://user-images.githubusercontent.com/10065904/89878172-79642a00-dbc1-11ea-8037-57d9aa8f54a1.png">
