### PR TITLE
Umstellung auf rex_markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   - Dokumentation angepasst:
     - README-Dateien
     - `plugins/documentation/docs/de_de/howto_integration.md` ("Editor integrieren")
+- Da MarkItUp ohnehin für Markdown den Core-Vendor benutzt, ist die eigene Markdown-Klasse auf
+  "deprecated" gesetzt. Die Formatierung ist auf `rex_markdown` umgestellt.
   
 ### Bugfixes
 

--- a/lib/MarkItUp.php
+++ b/lib/MarkItUp.php
@@ -121,8 +121,17 @@ class Markitup
 
         switch ($type) {
             case 'markdown':
-                $parser = new Markdown();
-                return self::replaceYFormLink($parser->text($content));
+                /**
+                 * Der alte Code (bis V3.7) setze auf der eigenen Markdown-Klasse auf.
+                 * Da Markdown in längst im REDAXO-Core steht (rex_markdown) und auch
+                 * MarkItUp den Core-Vendor nutzt, kann man auch gleich auf rex_markdown gehen.
+                 * 
+                 * TODO: alten Code entfernen
+                 */
+                $parser = \rex_markdown::factory();
+                return self::replaceYFormLink($parser->parse($content));
+                //$parser = new Markdown();
+                //return self::replaceYFormLink($parser->text($content));
                 break;
             case 'textile':
                 $parser = new Textile();

--- a/lib/Markdown.php
+++ b/lib/Markdown.php
@@ -4,6 +4,11 @@ namespace FriendsOfRedaxo\MarkItUp;
 
 use Parsedown;
 
+/**
+ * 
+ * @package FriendsOfRedaxo\MarkItUp
+ * @deprecated 4.0.0 Die Klasse soll durch rex_markdown ersetzt werden
+ */
 class Markdown extends Parsedown
 {
 }


### PR DESCRIPTION
In `lib/Markdown.php` stellt MarkItUp seit alters her den markdown-Parser bereit. Früher gab es wohl mal einen eigenen Vendor dazu, der ist aber schon länger durch den REDAXO-internen ersetzt. Dieser PR macht un den konsequenten letzten Schritt, auch die Klasse `FriendsOfRedaxo\MarkItUp\Markdown` zurückzubauen.

- `FriendsOfRedaxo\MarkItUp\Markdown` ist als `deprecated` markiert.
- Die Addon-internen Aufrufe sind auf `rex_markdown' geändert.