### PR TITLE
PHP 8.1, REX 5.15

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -23,4 +23,6 @@ conflicts:
         textile: '*'
 
 requires:
-    redaxo: '^5.2.0'
+    php:
+        version: '>=8.1'
+    redaxo: '^5.15.0'


### PR DESCRIPTION
Mindesanforderungen auf REDAXO 5.15 (bisher das uralte 5.2) und damit einhergehend PHP 8.1.