### PR TITLE
Beta2 (Doku-Plugin aufgelöst, Update-Bug, PHP8.1/REX5.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@
   - Freischalten über Berechtigungen (`markitup[manual]`, `markitup[developer]`)
 - Voraussetzungen angehoben: PHP 8.1 und REDAXO 5.15
 
-### Features (zusätzlich zu beta1)
+### Bugfix
 
-- Beim Update auf 3.8 wurde die Cache.php nicht gefunden da nun im Namespace (@madiko)
+- Beim Update auf 3.8beta1 wurde die Cache.php nicht gefunden da nun im Namespace (@madiko)
 
 ## 3.8.0-beta1 – 22.02.2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # MarkItUp Changelog
 
+## 3.8.0-beta2 – 29.02.2024
+
+### Features (zusätzlich zu beta1)
+
+- Documentation-Plugin aufgelöst. 
+  - Die Handbuchseiten werden in der `package.yml`) als SubPages angelegt
+  - Umgruppiert: Handbuch für Autoren und Handbuch für Entwickler
+  - Freischalten über Berechtigungen (`markitup[manual]`, `markitup[developer]`)
+- Voraussetzungen angehoben: PHP 8.1 und REDAXO 5.15
+
+### Features (zusätzlich zu beta1)
+
+- Beim Update auf 3.8 wurde die Cache.php nicht gefunden da nun im Namespace (@madiko)
+
 ## 3.8.0-beta1 – 22.02.2024
 
 ### Features

--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: markitup
-version: '3.8.0-beta1'
+version: '3.8.0-beta2'
 author: Friends Of REDAXO
 supportpage: github.com/FriendsOfREDAXO/markitup
 

--- a/update.php
+++ b/update.php
@@ -30,4 +30,5 @@ rex_sql_table::get(rex::getTable('markitup_snippets'))
     ->ensure();
 
 // Profilbezogenes JS|CSS neu generieren
+include __DIR__ . '/lib/Cache.php';
 echo Cache::update();


### PR DESCRIPTION
- Documentation-Plugin aufgelöst. 
  - Die Handbuchseiten werden in der `package.yml`) als SubPages angelegt
  - Umgruppiert: Handbuch für Autoren und Handbuch für Entwickler
  - Freischalten über Berechtigungen (`markitup[manual]`, `markitup[developer]`)
- Voraussetzungen angehoben: PHP 8.1 und REDAXO 5.15
- Beim Update auf 3.8beta1 wurde die Cache.php nicht gefunden da nun im Namespace (@madiko)
