### PR TITLE
TODO etc. abgearbeitet

### DIFF
--- a/lib/Cache.php
+++ b/lib/Cache.php
@@ -35,9 +35,15 @@ class Cache
             ->setQuery('SELECT `name`, `type`, `minheight`, `maxheight`, `markitup_buttons` FROM `' . rex::getTable('markitup_profiles') . '` ORDER BY `name` ASC')
             ->getArray();
 
-        // Liste der Sprachen, die in "snippets" vorkommen plus '--' (=Fallback bzw. für alle anderen)
+        /**
+         * Liste der Sprachen, die in "snippets" vorkommen plus '--' (=Fallback bzw. für alle anderen).
+         * @var array<string> $languages
+         */
         $languages = rex_sql::factory()
             ->setQuery('SELECT DISTINCT `lang` FROM `' . rex::getTable('markitup_snippets') . '`')
+            // REXSTAN: Parameter $fetchType of method rex_sql::getArray() expects 2|3|12, 7 given.
+            // Es liegt daran, dass in rex_sql nur wenige der PDO::Fetch... hinterlegt sind. Ignorierbar.
+            // @phpstan-ignore-next-line
             ->getArray(fetchType: PDO::FETCH_COLUMN);
         $languages = array_unique(array_merge(['--'], $languages));
         $fallback = array_unique(
@@ -181,8 +187,8 @@ class Cache
             $buttonString .= '{';
 
             foreach (['name', 'key', 'openWith', 'closeWith', 'className', 'replaceWith'] as $property) {
-                if (!empty($markItUpButtons[$profileButton][$property])) {
-                    if (in_array($property, ['openWith', 'closeWith'])) {
+                if (isset($markItUpButtons[$profileButton][$property])) {
+                    if (in_array($property, ['openWith', 'closeWith'], true)) {
                         $buttonString .= '  ' . $property . ":'" . $markItUpButtons[$profileButton][$property][$type] . "'," . PHP_EOL;
                     } elseif ('replaceWith' === $property) {
                         $buttonString .= '  ' . $property . ':' . $markItUpButtons[$profileButton][$property][$type] . ',' . PHP_EOL;
@@ -195,7 +201,7 @@ class Cache
             }
 
             // Start - dropdown
-            if (!empty($options)) {
+            if (0 < count($options)) {
                 $buttonString .= '  dropMenu: [';
 
                 foreach ($options as $option) {
@@ -207,7 +213,7 @@ class Cache
                         }
                     } else {
                         foreach (['name', 'key', 'openWith', 'closeWith', 'replaceWith'] as $property) {
-                            if (!empty($markItUpButtons[$profileButton]['children'][$option][$property])) {
+                            if (isset($markItUpButtons[$profileButton]['children'][$option][$property])) {
                                 if (in_array($property, ['openWith', 'closeWith'], true)) {
                                     $buttonString .= '  ' . $property . ':\'' . $markItUpButtons[$profileButton]['children'][$option][$property][$type] . '\',' . PHP_EOL;
                                 } else {

--- a/lib/Textile.php
+++ b/lib/Textile.php
@@ -24,8 +24,8 @@ class Textile extends Parser
     public static function custom_parse(string $code, bool $restricted = false, string $doctype = 'xhtml'): string
     {
         $instance = self::getInstance($doctype);
-        // TODO: Code übersichtlicher
-        return $restricted ? $instance->setRestricted(true)->parse($code) : $instance->setRestricted(false)->parse($code);
+        $instance->setRestricted($restricted);
+        return $instance->parse($code);
     }
 
     private static function getInstance(string $doctype = 'xhtml'): self

--- a/pages/profiles.php
+++ b/pages/profiles.php
@@ -16,7 +16,7 @@ use rex_sql;
 $func = rex_request('func', 'string');
 
 if ('' === $func) {
-    $list = rex_list::factory("SELECT `id`, `name`, `description`, `type`, CONCAT('markitupEditor-',`name`) as `cssclass` FROM `" . rex::getTable('markitup_profiles') . '` ORDER BY `name` ASC');
+    $list = rex_list::factory('SELECT `id`, `name`, `description`, `type`, CONCAT("markitupEditor-",`name`) as `cssclass` FROM `' . rex::getTable('markitup_profiles') . '` ORDER BY `name` ASC');
     $list->addTableAttribute('class', 'table-striped');
     $list->setNoRowsMessage($this->i18n('profiles_norowsmessage'));
 
@@ -68,15 +68,11 @@ if ('' === $func) {
     $field->setLabel($this->i18n('profiles_label_name'));
     $field->getValidator()->add('notEmpty', $this->i18n('validate_empty', $this->i18n('profiles_label_name')));
     $field->getValidator()->add('custom', $this->i18n('validate_unique', $this->i18n('profiles_label_name')), static function ($value) use ($id) {
-        // TODO: SQL verbessern ?
-        $profiles = rex_sql::factory()->getArray('SELECT id FROM ' . rex::getTable('markitup_profiles') . ' WHERE name LIKE :name LIMIT 1', [':name' => $value]);
-        if (0 === count($profiles)) {
-            return true;
-        }
-        if ($profiles[0]['id'] === $id) {
-            return true;
-        }
-        return false;
+        $profiles = rex_sql::factory()
+            ->setTable(rex::getTable('markitup_profiles'))
+            ->setWhere('name LIKE :name', [':name' => $value])
+            ->select('id');
+        return 0 === $profiles->getRows() || $id === $profiles->getValue('id');
     });
     // End - add name-field
 

--- a/pages/snippets.php
+++ b/pages/snippets.php
@@ -88,15 +88,11 @@ if ('' === $func) {
     }
     $select->setSize(1);
     $field->getValidator()->add('custom', $this->i18n('validate_unique', $this->i18n('snippets_label_name') . ' + ' . $this->i18n('snippets_label_lang')), static function ($value) use ($nfield, $id) {
-        // TODO: SQL verbessern ?
-        $snippets = rex_sql::factory()->getArray('SELECT id FROM ' . rex::getTable('markitup_snippets') . ' WHERE name LIKE :name && lang LIKE :lang LIMIT 1', [':name' => $value, ':lang' => $nfield->getValue()]);
-        if (0 === count($snippets)) {
-            return true;
-        }
-        if ($snippets[0]['id'] === $id) {
-            return true;
-        }
-        return false;
+        $snippets = rex_sql::factory()
+            ->setTable(rex::getTable('markitup_snippets'))
+            ->setWhere('name LIKE :name && lang LIKE :lang', [':lang' => $value, ':name' => $nfield->getValue()])
+            ->select('id');
+        return 0 === $snippets->getRows() || $id === $snippets->getValue('id');
     });
     // End - add lang-field
 


### PR DESCRIPTION
Aus dem vorigen PR #143 finden sich einige Einträge zu Stellen, die man etwas besser formulieren könnte,

- SQL-Abfragen wurden - sofern die Abfrage entsprechend umbaubar war - in einzelne `$sql->setXyz(...)`umgebaut, um RexStan-Empfehlungen zu folgen
- Funktions-Parameter und Variablen wurden mit Datentypen versehen, so dass die IDE und RexStan Probleme besser erkennen können. *1
- Fehler im vorherigen PR (JS wude nicht richtig generiert) behoben.

*1: das könnte in der Anwendung zu einem BC-Effekt führen, wenn bisher Datentypen übergeben wurde, die seitens PHP stillschweigend in passende Typen konvertiert wurden. Jetzt müssen Schnittstellen (Methoden) typ-korrekt bedient werden.